### PR TITLE
set default msg_size as 4M if all_sizes=1

### DIFF
--- a/generic.c
+++ b/generic.c
@@ -778,7 +778,7 @@ void set_default_args() {
     win_size = 256;
     iterations = 50;
     warmup = 10;
-    msg_size = 0;
+    msg_size = (all_sizes ? (4 * 1024 * 1024) : 0);
 }
 
 void run_benchmark(MPI_Comm comm)


### PR DESCRIPTION
The default global value for all_sizes is 1 if not set otherwise by passing some particular msg_size as an argument. Also, if the benchmark runs for all_sizes, it will handle the msg_size 0 as the start. If someone sets the global all_sizes as 0, it will set the default msg_size to 0. The problem arises during the bulk allocation of the buffer. If the default msg_size is set to 0, it will assign a zero-size buffer that fails one-sided and other operations for msg_size > 0.

Signed-off-by: Subhadeep Bhattacharya <subhadeepb@nvidia.com>